### PR TITLE
Adding default to GCP cloud ID

### DIFF
--- a/cloudprovider/gcp/cloud_id.go
+++ b/cloudprovider/gcp/cloud_id.go
@@ -9,6 +9,9 @@ import (
 )
 
 func GetCloudID(audience string) (string, error) {
+	if audience == "" {
+		audience = "akeyless.io"
+	}
 	signedJWT, err := idtoken.NewTokenSource(context.Background(), audience)
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve signed JWT: %w", err)


### PR DESCRIPTION
This is not breaking BC since an empty string would return an error